### PR TITLE
Accessibility bug fix: NVDA scenario is broken because first item is always selected.

### DIFF
--- a/src/connect/ConnectWizard.ts
+++ b/src/connect/ConnectWizard.ts
@@ -199,7 +199,7 @@ export class ConnectWizard {
             totalSteps: this.NumberOfSteps,
             placeholder: `Choose a service to redirect to your machine`,
             items: serviceChoices.sort((s1, s2) => s1.label < s2.label ? -1 : 1),
-            activeItem: serviceChoices[0]
+            activeItem: null
         });
         this._result.resourceName = pick.label;
 
@@ -261,7 +261,7 @@ export class ConnectWizard {
             totalSteps: this.NumberOfSteps,
             placeholder: `Choose the launch configuration to use to run your component locally`,
             items: choices,
-            activeItem: choices[0]
+            activeItem: null
         });
 
         if (pick.label === createNewLaunchConfigurationLabel) {
@@ -310,7 +310,7 @@ export class ConnectWizard {
             totalSteps: this.NumberOfSteps,
             placeholder: `Isolate your local version of "${this._result.resourceName}" from other developers?`,
             items: choices,
-            activeItem: choices[0]
+            activeItem: null
         });
         this._result.isolateAs = (pick === yesChoice) ? routingHeader : null;
 


### PR DESCRIPTION
### Solution Space:

This PR fixes the A11Y (Accessibility specific bug) for non-nvda users it might not occur that the first element is always selected but got folks who use NVDA or JAWS are very much dependent on the Scrren SPeech reader and in that case it is important we don't auto choose option for them and let them select of its own.

* Also, by doing this the `placehoder` vscode text gets read outloud. In case of presetlect first element as choice it reads the `selected element` 

Thank you so much and fyi: @daniv-msft, @hsubramanianaks , @elenavillamil , @Vidya2606 , @gambtho , @qpetraroia and @sabbour 🛡️ ⛩️ 
