### PR TITLE
Update change log version for 0310 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## [2.0.120230303]
+## [2.0.120230310]
 
 * CLI version update that includes:
   - Minor bug fixes


### PR DESCRIPTION
We skip released 0303 and while I update the description with new issues fixed, I forgot to update the title to new release version.