### PR TITLE
change to service.name to show correct ingress url's

### DIFF
--- a/src/clients/KubectlClient.ts
+++ b/src/clients/KubectlClient.ts
@@ -151,7 +151,7 @@ export class KubectlClient implements IClient {
                     const usesHttps: boolean = ingressItem.spec.tls != null && ingressItem.spec.tls.find(item => item != null && item.hosts != null && item.hosts.indexOf(ingressRule.host) > -1) != null;
 
                     for (const path of ingressRule.http.paths) {
-                        if (path == null || path.backend == null || path.backend.serviceName == null) {
+                        if (path == null || path.backend == null || path.backend.service == null || path.backend.service.name == null) {
                             continue;
                         }
 

--- a/src/tests/suites/KubectlClient-Test.ts
+++ b/src/tests/suites/KubectlClient-Test.ts
@@ -21,7 +21,7 @@ describe(`KubectlClient Test`, () => {
             "apiVersion": "v1",
             "items": [
                 {
-                    "apiVersion": "extensions/v1beta1",
+                    "apiVersion": "networking.k8s.io/v1",
                     "kind": "Ingress",
                     "metadata": {
                         "annotations": {
@@ -41,7 +41,6 @@ describe(`KubectlClient Test`, () => {
                         "name": "bikesharingweb",
                         "namespace": "dev",
                         "resourceVersion": "1314825",
-                        "selfLink": "/apis/extensions/v1beta1/namespaces/dev/ingresses/bikesharingweb",
                         "uid": "8044fe48-4e8c-454b-b8de-553d0988666e"
                     },
                     "spec": {
@@ -52,8 +51,12 @@ describe(`KubectlClient Test`, () => {
                                     "paths": [
                                         {
                                             "backend": {
-                                                "serviceName": "bikesharingweb",
-                                                "servicePort": "http"
+                                                "service": {
+                                                    "name": "bikesharingweb",
+                                                    "port": {
+                                                        "number": 80
+                                                    }
+                                                }
                                             },
                                             "path": "/"
                                         }
@@ -73,7 +76,7 @@ describe(`KubectlClient Test`, () => {
                     }
                 },
                 {
-                    "apiVersion": "extensions/v1beta1",
+                    "apiVersion": "networking.k8s.io/v1",
                     "kind": "Ingress",
                     "metadata": {
                         "annotations": {
@@ -93,7 +96,6 @@ describe(`KubectlClient Test`, () => {
                         "name": "gateway",
                         "namespace": "dev",
                         "resourceVersion": "1314824",
-                        "selfLink": "/apis/extensions/v1beta1/namespaces/dev/ingresses/gateway",
                         "uid": "0b61f6fa-f6ad-4a01-b1b2-89255bed41ca"
                     },
                     "spec": {
@@ -104,8 +106,12 @@ describe(`KubectlClient Test`, () => {
                                     "paths": [
                                         {
                                             "backend": {
-                                                "serviceName": "gateway",
-                                                "servicePort": "http"
+                                                "service": {
+                                                    "name": "gateway",
+                                                    "port": {
+                                                        "number": 80
+                                                    }
+                                                }
                                             },
                                             "path": "/"
                                         }
@@ -150,6 +156,118 @@ describe(`KubectlClient Test`, () => {
         const kubectlClient = new KubectlClient(`my/path/kubectl.exe`, commandRunnerStub, accountContextManagerStub, loggerStub);
         const ingresses: IKubernetesIngress[] = await kubectlClient.getIngressesAsync(`dev`, `c:/users/alias/.kube/config`, true);
 
+        expect(ingresses.length).to.equal(0);
+    });
+
+    it(`getIngressesAsync when the kubectl command returns ingresses without service`, async () => {
+        const returnString = `{
+            "apiVersion": "v1",
+            "items": [
+                {
+                    "apiVersion": "networking.k8s.io/v1",
+                    "kind": "Ingress",
+                    "metadata": {
+                        "annotations": {
+                            "kubernetes.io/ingress.class": "traefik",
+                            "meta.helm.sh/release-name": "bikesharingsampleapp",
+                            "meta.helm.sh/release-namespace": "dev"
+                        },
+                        "creationTimestamp": "2020-05-12T01:02:49Z",
+                        "generation": 1,
+                        "labels": {
+                            "app": "bikesharingweb",
+                            "app.kubernetes.io/managed-by": "Helm",
+                            "chart": "bikesharingweb-0.1.0",
+                            "heritage": "Helm",
+                            "release": "bikesharingsampleapp"
+                        },
+                        "name": "bikesharingweb",
+                        "namespace": "dev",
+                        "resourceVersion": "1314825",
+                        "uid": "8044fe48-4e8c-454b-b8de-553d0988666e"
+                    },
+                    "spec": {
+                        "rules": [
+                            {
+                                "host": "dev.bikesharingweb.j7l6v4gz8d.eus.mindaro.io",
+                                "http": {
+                                    "paths": [
+                                        {
+                                            "backend": {},
+                                            "path": "/"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "loadBalancer": {
+                            "ingress": [
+                                {
+                                    "ip": "13.72.80.227"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "apiVersion": "networking.k8s.io/v1",
+                    "kind": "Ingress",
+                    "metadata": {
+                        "annotations": {
+                            "kubernetes.io/ingress.class": "traefik",
+                            "meta.helm.sh/release-name": "bikesharingsampleapp",
+                            "meta.helm.sh/release-namespace": "dev"
+                        },
+                        "creationTimestamp": "2020-05-12T01:02:49Z",
+                        "generation": 1,
+                        "labels": {
+                            "app": "gateway",
+                            "app.kubernetes.io/managed-by": "Helm",
+                            "chart": "gateway-0.1.0",
+                            "heritage": "Helm",
+                            "release": "bikesharingsampleapp"
+                        },
+                        "name": "gateway",
+                        "namespace": "dev",
+                        "resourceVersion": "1314824",
+                        "uid": "0b61f6fa-f6ad-4a01-b1b2-89255bed41ca"
+                    },
+                    "spec": {
+                        "rules": [
+                            {
+                                "host": "dev.gateway.j7l6v4gz8d.eus.mindaro.io",
+                                "http": {
+                                    "paths": [
+                                        {
+                                            "backend": {
+                                                "service": {}
+                                            },
+                                            "path": "/"
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "status": {
+                        "loadBalancer": {
+                            "ingress": [
+                                {
+                                    "ip": "13.72.80.227"
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }`;
+        const commandRunnerStub = sinon.createStubInstance(CommandRunner);
+        commandRunnerStub.runAsync.resolves(returnString);
+        const kubectlClient = new KubectlClient(`my/path/kubectl.exe`, commandRunnerStub, accountContextManagerStub, loggerStub);
+        let ingresses: IKubernetesIngress[];
+        ingresses = await kubectlClient.getIngressesAsync(`dev`, `c:/users/alias/.kube/config`, false);
         expect(ingresses.length).to.equal(0);
     });
 


### PR DESCRIPTION
This change is to fix the issue of not showing ingress url's in kubernetes status bar due to issue of using deprecated property names. ingress.items.spec.rules.http.paths.backend.serviceName was changed to ingress.items.spec.rules.http.paths.backend.service.name as part of this PR [here](https://github.com/kubernetes/kubernetes/pull/89778). More details [here](https://stackoverflow.com/questions/64125048/get-error-unknown-field-servicename-in-io-k8s-api-networking-v1-ingressbacken). 

After this PR : (note displays the ingress url's) before it wasn't displaying unless if cluster ingress was v1beta which is deprecated now.

![image](https://github.com/Azure/vscode-bridge-to-kubernetes/assets/105889062/6f85c3ea-d5dd-4ea7-a28b-206e94c32873)
