### PR TITLE
add codesign if mac/arm64 arch

### DIFF
--- a/src/tests/suites/BridgeClient-Test.ts
+++ b/src/tests/suites/BridgeClient-Test.ts
@@ -1,12 +1,14 @@
 import { expect } from "chai";
-import { describe, it } from 'mocha';
+import { describe, it, after } from 'mocha';
 import * as sinon from 'sinon';
 import { BridgeClient } from "../../clients/BridgeClient";
 import { CommandRunner } from '../../clients/CommandRunner';
 import { ResourceType } from "../../connect/ResourceType";
 import { loggerStub } from '../CommonTestObjects';
+import { fileSystem } from "../../utility/FileSystem";
 
 describe('BridgeClient Tests', () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
     it('connectAsync should work with multiple containers', async () => {
         loggerStub.trace.reset();
         loggerStub.trace.onCall(0).returns();
@@ -62,5 +64,50 @@ describe('BridgeClient Tests', () => {
         expect(commandRunnerStub.runAsync.getCall(0).args[1].length).not.to.equal(0);
         const args = commandRunnerStub.runAsync.getCall(0).args[1];
         expect(args.indexOf("--container")).to.equal(-1);
+    });
+
+    it('versionAsync should work', async () => {
+        const commandRunnerStub = sinon.createStubInstance(CommandRunner);
+        commandRunnerStub.runAsync.resolves("1.0.20231212");
+        const bridgeClient = new BridgeClient("", "", commandRunnerStub, "", loggerStub);
+        const output = await bridgeClient.getVersionAsync();
+        expect(commandRunnerStub.runAsync.calledOnce).to.be.true;
+        expect(output).to.equal("1.0.20231212");
+    });
+
+    it('versionAsync should work when it is arm64 mac', async () => {
+        const commandRunnerStub = sinon.createStubInstance(CommandRunner);
+        commandRunnerStub.runAsync.resolves("1.0.20231212");
+        Object.defineProperty(process, 'platform', {
+            value: 'darwin'
+        });
+        Object.defineProperty(process, 'arch', {
+            value: 'arm64'
+        });
+        const fileSystemStub = sinon.stub(fileSystem, 'existsAsync');
+        fileSystemStub.resolves(true);
+        const bridgeClient = new BridgeClient("", "", commandRunnerStub, "", loggerStub);
+        const output = await bridgeClient.getVersionAsync();
+        expect(commandRunnerStub.runAsync.calledTwice).to.be.true;
+        const args = commandRunnerStub.runAsync.getCall(0).args[0];
+        expect(args.indexOf("/usr/bin/codesign")).to.equal(0);
+        expect(output).to.equal("1.0.20231212");
+    });
+
+    it('versionAsync should work when it is arm64 mac and it is already signed', async () => {
+        const commandRunnerStub = sinon.createStubInstance(CommandRunner);
+        const args: string[] = ['-s', '-', ''];
+        commandRunnerStub.runAsync.withArgs("/usr/bin/codesign", args, null, null).rejects(new Error("is already signed"));
+        commandRunnerStub.runAsync.resolves("1.0.20231212");
+        const bridgeClient = new BridgeClient("", "", commandRunnerStub, "", loggerStub);
+        const output = await bridgeClient.getVersionAsync();
+        expect(commandRunnerStub.runAsync.callCount).to.equal(3);
+        const expectedArgs = commandRunnerStub.runAsync.getCall(0).args[0];
+        expect(expectedArgs.indexOf("/usr/bin/codesign")).to.equal(0);
+        expect(output).to.equal("1.0.20231212");
+    });
+
+    after(() => {
+        Object.defineProperty(process, 'platform', originalPlatform);
     });
 });


### PR DESCRIPTION
This PR fixes https://github.com/Azure/vscode-bridge-to-kubernetes/issues/81 and code sign is required for M1 Mac's (arm64 darwin) so that binaries can be executed. getVersionAsync is the first method to use dsc/bridge binary. So, adding it here make sense so that one time this binary will be codesigned. 