### PR TITLE
Bump Axios and Xml2js dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "got": "^11.0.0",
-        "vscode-tas-client": "^0.1.22",
+        "vscode-tas-client": "^0.1.75",
         "lodash": "^4.17.21",
         "username": "^5.1.0",
         "portfinder": "^1.0.28",
@@ -35,7 +35,7 @@
         "c8": "^8.0.1",
         "ts-loader": "^9.4.2",
         "copy": "^0.0.1",
-        "@vscode/vsce": "^2.15.0",
+        "@vscode/vsce": "^2.19.0",
         "del-cli": "^5.0.0",
         "webpack": "^5.76.0",
         "@types/chai": "^4.3.5",
@@ -1077,11 +1077,11 @@
       }
     },
     "node_modules/tas-client": {
-      "version": "0.1.58",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.58.tgz",
-      "integrity": "sha512-fOWii4wQXuo9Zl0oXgvjBzZWzKc5MmUR6XQWX93WU2c1SaP1plPo/zvXP8kpbZ9fvegFOHdapszYqMTRq/SRtg==",
+      "version": "0.1.73",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.73.tgz",
+      "integrity": "sha512-UDdUF9kV2hYdlv+7AgqP2kXarVSUhjK7tg1BUflIRGEgND0/QoNpN64rcEuhEcM8AIbW65yrCopJWqRhLZ3m8w==",
       "dependencies": {
-        "axios": "^0.26.1"
+        "axios": "^1.6.1"
       }
     },
     "node_modules/mimic-fn": {
@@ -1341,11 +1341,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
+      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
       "dependencies": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/interpret": {
@@ -3565,6 +3567,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5008,11 +5023,11 @@
       }
     },
     "node_modules/vscode-tas-client": {
-      "version": "0.1.63",
-      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.63.tgz",
-      "integrity": "sha512-TY5TPyibzi6rNmuUB7eRVqpzLzNfQYrrIl/0/F8ukrrbzOrKVvS31hM3urE+tbaVrnT+TMYXL16GhX57vEowhA==",
+      "version": "0.1.75",
+      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.75.tgz",
+      "integrity": "sha512-/+ALFWPI4U3obeRvLFSt39guT7P9bZQrkmcLoiS+2HtzJ/7iPKNt5Sj+XTiitGlPYVFGFc0plxX8AAp6Uxs0xQ==",
       "dependencies": {
-        "tas-client": "0.1.58"
+        "tas-client": "0.1.73"
       },
       "engines": {
         "vscode": "^1.19.1"
@@ -5163,6 +5178,11 @@
         "@webassemblyjs/ast": "1.11.6",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/indent-string": {
       "version": "5.0.0",
@@ -5932,9 +5952,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
       "funding": [
         {
           "type": "individual",
@@ -8478,11 +8498,25 @@
       "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
     },
     "axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.4.tgz",
+      "integrity": "sha512-heJnIs6N4aa1eSthhN9M5ioILu8Wi8vmQW9iHQ9NUvfkJb0lEEDUiIdQNAuBtfUt3FxReaKdpQA5DbmMOqzF/A==",
       "requires": {
-        "follow-redirects": "^1.14.8"
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "azure-devops-node-api": {
@@ -9447,7 +9481,8 @@
       "dev": true
     },
     "execa": {
-      "version": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
       "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
       "requires": {
         "cross-spawn": "^7.0.3",
@@ -9589,9 +9624,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-      "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q=="
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
+      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw=="
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -10721,7 +10756,7 @@
         "minimatch": "5.0.1",
         "ms": "2.1.3",
         "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
+        "serialize-javascript": "3.1.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "workerpool": "6.2.1",
@@ -11292,6 +11327,11 @@
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "psl": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
@@ -11619,7 +11659,8 @@
       }
     },
     "serialize-javascript": {
-      "version": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-3.1.0.tgz",
       "integrity": "sha512-JIJT1DGiWmIKhzRsG91aS6Ze4sFUrYbltlkg2onR5OrnNM02Kl/hnY/T4FN2omvyeBbQmMJv+K4cPOpGzOTFBg==",
       "dev": true,
       "requires": {
@@ -11963,11 +12004,11 @@
       }
     },
     "tas-client": {
-      "version": "0.1.58",
-      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.58.tgz",
-      "integrity": "sha512-fOWii4wQXuo9Zl0oXgvjBzZWzKc5MmUR6XQWX93WU2c1SaP1plPo/zvXP8kpbZ9fvegFOHdapszYqMTRq/SRtg==",
+      "version": "0.1.73",
+      "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.73.tgz",
+      "integrity": "sha512-UDdUF9kV2hYdlv+7AgqP2kXarVSUhjK7tg1BUflIRGEgND0/QoNpN64rcEuhEcM8AIbW65yrCopJWqRhLZ3m8w==",
       "requires": {
-        "axios": "^0.26.1"
+        "axios": "^1.6.1"
       }
     },
     "telaug": {
@@ -12014,7 +12055,7 @@
         "@jridgewell/trace-mapping": "^0.3.17",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
-        "serialize-javascript": "^6.0.1",
+        "serialize-javascript": "3.1.0",
         "terser": "^5.16.8"
       }
     },
@@ -12270,7 +12311,7 @@
       "resolved": "https://registry.npmjs.org/username/-/username-5.1.0.tgz",
       "integrity": "sha512-PCKbdWw85JsYMvmCv5GH3kXmM66rCd9m1hBEDutPNv94b/pqCMT4NtcKyeWYvLFiE8b+ha1Jdl8XAaUdPn5QTg==",
       "requires": {
-        "execa": "^1.0.0",
+        "execa": "5.1.1",
         "mem": "^4.3.0"
       }
     },
@@ -12329,11 +12370,11 @@
       "integrity": "sha512-5+4OdwrRinoTsE8i6s8pPY+BbGh5U7DNAA/3pn5wlOhvQpivaBMdi89bRKfdAffPjt/bvHodje4BFm5GSNjFxQ=="
     },
     "vscode-tas-client": {
-      "version": "0.1.63",
-      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.63.tgz",
-      "integrity": "sha512-TY5TPyibzi6rNmuUB7eRVqpzLzNfQYrrIl/0/F8ukrrbzOrKVvS31hM3urE+tbaVrnT+TMYXL16GhX57vEowhA==",
+      "version": "0.1.75",
+      "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.75.tgz",
+      "integrity": "sha512-/+ALFWPI4U3obeRvLFSt39guT7P9bZQrkmcLoiS+2HtzJ/7iPKNt5Sj+XTiitGlPYVFGFc0plxX8AAp6Uxs0xQ==",
       "requires": {
-        "tas-client": "0.1.58"
+        "tas-client": "0.1.73"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -208,7 +208,7 @@
         "@types/sinon": "^10.0.16",
         "@types/vscode": "1.74.0",
         "@vscode/test-electron": "^2.3.3",
-        "@vscode/vsce": "^2.15.0",
+        "@vscode/vsce": "^2.19.0",
         "c8": "^8.0.1",
         "chai": "^4.3.7",
         "copy": "^0.0.1",
@@ -243,7 +243,7 @@
         "tmp": "^0.1.0",
         "username": "^5.1.0",
         "vscode-kubernetes-tools-api": "^1.3.0",
-        "vscode-tas-client": "^0.1.22",
+        "vscode-tas-client": "^0.1.75",
         "watchpack": "^2.3.1"
     },
     "overrides": {


### PR DESCRIPTION
Bumps [xml2js](https://github.com/Leonidas-from-XIV/node-xml2js) to 0.5.0 and updates ancestor dependency [@vscode/vsce](https://github.com/Microsoft/vsce). These dependencies need to be updated together.

Updates xml2js from 0.4.23 to 0.5.0

Bumps [axios](https://github.com/axios/axios) to 1.6.2 and updates ancestor dependency vscode-tas-client. These dependencies need to be updated together.

Updates axios from 0.26.1 to 1.6.2