### PR TITLE
Fix code scanning alert no. 1: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/src/utility/StringUtility.ts
+++ b/src/utility/StringUtility.ts
@@ -29,7 +29,7 @@ export class StringUtility {
 
         // Make sure that the username exists and only contains ASCII characters.
         if (username.length === 0 || /[^\u0000-\u007f]/.test(username)) {
-            username = crypto.createHash(`md5`).update(username).digest(`hex`);
+            username = crypto.createHash(`sha256`).update(username).digest(`hex`);
         }
 
         // Make sure we only take the first 8 characters of the username.


### PR DESCRIPTION
Fixes [https://github.com/Azure/vscode-bridge-to-kubernetes/security/code-scanning/1](https://github.com/Azure/vscode-bridge-to-kubernetes/security/code-scanning/1)

To fix the problem, we need to replace the use of the MD5 hashing algorithm with a stronger algorithm like SHA-256. This involves changing the `crypto.createHash('md5')` call to `crypto.createHash('sha256')` in the `generateRoutingHeaderAsync` method of the `StringUtility` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
