### PR TITLE
download from github instead of storage blob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "command-exists": "^1.2.8",
         "guid-typescript": "^1.0.9",
         "node-fetch": "^2.6.7",
-        "@microsoft/vscode-file-downloader-api": "^1.0.1",
         "chokidar": "^3.5.3",
         "@kubernetes/client-node": "^0.22.3",
         "opener": "^1.5.1",
@@ -57,7 +56,7 @@
       "engines": {
         "node": ">=16.20.x",
         "npm": ">=8.19.x",
-        "vscode": "^1.74.0"
+        "vscode": "^1.95.0"
       },
       "optionalDependencies": {
         "bufferutil": "^4.0.8",
@@ -1569,18 +1568,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
@@ -2101,15 +2088,6 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
-    },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/cheerio": {
       "version": "1.0.0-rc.12",
@@ -2971,15 +2949,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/webpack/node_modules/estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4.0"
       }
     },
     "node_modules/css-select": {
@@ -3862,18 +3831,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4120,18 +4077,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
       }
     },
     "node_modules/resolve-alpn": {
@@ -4677,12 +4622,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/wrap-ansi/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
     },
     "node_modules/normalize-url": {
       "version": "6.1.0",
@@ -5303,21 +5242,6 @@
       "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -5607,11 +5531,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@microsoft/vscode-file-downloader-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/vscode-file-downloader-api/-/vscode-file-downloader-api-1.0.1.tgz",
-      "integrity": "sha512-cO9n/IpTMbXizz5YcEkiuRyX5r66SBY/3LnrlroyXbQXrgDdaKecfV3n4viTcvp9O//QF2AxcBfDZex2d4VSTg=="
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -7532,11 +7451,6 @@
       "requires": {
         "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
       }
-    },
-    "@microsoft/vscode-file-downloader-api": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/vscode-file-downloader-api/-/vscode-file-downloader-api-1.0.1.tgz",
-      "integrity": "sha512-cO9n/IpTMbXizz5YcEkiuRyX5r66SBY/3LnrlroyXbQXrgDdaKecfV3n4viTcvp9O//QF2AxcBfDZex2d4VSTg=="
     },
     "@nevware21/ts-async": {
       "version": "0.4.0",
@@ -10823,12 +10737,6 @@
         "aggregate-error": "^4.0.0"
       }
     },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -10998,33 +10906,6 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
           }
         }
       }
@@ -12214,12 +12095,6 @@
             "esrecurse": "^4.3.0",
             "estraverse": "^4.1.1"
           }
-        },
-        "estraverse": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-          "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-          "dev": true
         }
       }
     },
@@ -12317,21 +12192,6 @@
           "requires": {
             "color-convert": "^2.0.1"
           }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,263 +1,262 @@
 {
-    "name": "mindaro",
-    "displayName": "Bridge to Kubernetes",
-    "description": "Rapid Kubernetes development for teams",
-    "version": "2.0.120240111",
-    "icon": "images/bridge128.png",
-    "preview": false,
-    "publisher": "mindaro",
-    "qna": "marketplace",
-    "license": "MIT",
-    "engines": {
-        "vscode": "^1.95.0",
-        "node": ">=16.20.x",
-        "npm": ">=8.19.x"
-    },
-    "categories": [
-        "Azure",
-        "Debuggers",
-        "Other"
+  "name": "mindaro",
+  "displayName": "Bridge to Kubernetes",
+  "description": "Rapid Kubernetes development for teams",
+  "version": "2.0.120240111",
+  "icon": "images/bridge128.png",
+  "preview": false,
+  "publisher": "mindaro",
+  "qna": "marketplace",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.95.0",
+    "node": ">=16.20.x",
+    "npm": ">=8.19.x"
+  },
+  "categories": [
+    "Azure",
+    "Debuggers",
+    "Other"
+  ],
+  "keywords": [
+    "container",
+    "docker",
+    "kubernetes",
+    "Bridge",
+    "Bridge to Kubernetes",
+    "Azure Dev Spaces",
+    "azds",
+    "Local Process with Kubernetes",
+    "lpk",
+    "connect",
+    "cluster",
+    "debug",
+    "microservice",
+    "cloud native",
+    "kubernetes-extension-local-tunnel-debug-provider"
+  ],
+  "activationEvents": [
+    "*"
+  ],
+  "extensionKind": [
+    "workspace"
+  ],
+  "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
+  "main": "./dist/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "mindaro.open-menu",
+        "title": "Open Menu",
+        "category": "Bridge to Kubernetes"
+      },
+      {
+        "command": "mindaro.configure",
+        "title": "Configure",
+        "category": "Bridge to Kubernetes"
+      }
     ],
-    "keywords": [
-        "container",
-        "docker",
-        "kubernetes",
-        "Bridge",
-        "Bridge to Kubernetes",
-        "Azure Dev Spaces",
-        "azds",
-        "Local Process with Kubernetes",
-        "lpk",
-        "connect",
-        "cluster",
-        "debug",
-        "microservice",
-        "cloud native",
-        "kubernetes-extension-local-tunnel-debug-provider"
+    "debuggers": [
+      {
+        "type": "dev-spaces-connect-configuration",
+        "label": "Legacy Bridge to Kubernetes Configuration"
+      },
+      {
+        "type": "local-process-with-kubernetes.configuration",
+        "label": "Legacy Bridge to Kubernetes Configuration"
+      },
+      {
+        "type": "bridge-to-kubernetes.configuration",
+        "label": "Bridge to Kubernetes Configuration"
+      }
     ],
-    "activationEvents": [
-        "*"
-    ],
-    "extensionKind": [
-        "workspace"
-    ],
-    "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
-    "main": "./dist/extension",
-    "contributes": {
-        "commands": [
-            {
-                "command": "mindaro.open-menu",
-                "title": "Open Menu",
-                "category": "Bridge to Kubernetes"
-            },
-            {
-                "command": "mindaro.configure",
-                "title": "Configure",
-                "category": "Bridge to Kubernetes"
-            }
+    "taskDefinitions": [
+      {
+        "type": "bridge-to-kubernetes.resource",
+        "required": [
+          "resource",
+          "resourceType",
+          "ports"
         ],
-        "debuggers": [
-            {
-                "type": "dev-spaces-connect-configuration",
-                "label": "Legacy Bridge to Kubernetes Configuration"
-            },
-            {
-                "type": "local-process-with-kubernetes.configuration",
-                "label": "Legacy Bridge to Kubernetes Configuration"
-            },
-            {
-                "type": "bridge-to-kubernetes.configuration",
-                "label": "Bridge to Kubernetes Configuration"
-            }
-        ],
-        "taskDefinitions": [
-            {
-                "type": "bridge-to-kubernetes.resource",
-                "required": [
-                    "resource",
-                    "resourceType",
-                    "ports"
-                ],
-                "properties": {
-                    "resource": {
-                        "type": "string"
-                    },
-                    "resourceType": {
-                        "type": "string"
-                    },
-                    "ports": {
-                        "type": "array"
-                    },
-                    "isolateAs": {
-                        "type": "string"
-                    },
-                    "targetCluster": {
-                        "type": "string"
-                    },
-                    "targetNamespace": {
-                        "type": "string"
-                    },
-                    "targetContainer": {
-                        "type": "string"
-                    },
-                    "useKubernetesServiceEnvironmentVariables": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            {
-                "type": "bridge-to-kubernetes.service",
-                "required": [
-                    "service",
-                    "ports"
-                ],
-                "properties": {
-                    "service": {
-                        "type": "string"
-                    },
-                    "ports": {
-                        "type": "array"
-                    },
-                    "isolateAs": {
-                        "type": "string"
-                    },
-                    "targetCluster": {
-                        "type": "string"
-                    },
-                    "targetNamespace": {
-                        "type": "string"
-                    },
-                    "targetContainer": {
-                        "type": "string"
-                    },
-                    "useKubernetesServiceEnvironmentVariables": {
-                        "type": "boolean"
-                    }
-                }
-            },
-            {
-                "type": "local-process-with-kubernetes.service",
-                "required": [
-                    "service",
-                    "ports"
-                ],
-                "properties": {
-                    "service": {
-                        "type": "string"
-                    },
-                    "ports": {
-                        "type": "array"
-                    },
-                    "isolateAs": {
-                        "type": "string"
-                    }
-                }
-            },
-            {
-                "type": "dev-spaces.connect.service",
-                "required": [
-                    "service",
-                    "ports"
-                ],
-                "properties": {
-                    "service": {
-                        "type": "string"
-                    },
-                    "ports": {
-                        "type": "array"
-                    },
-                    "isolateAs": {
-                        "type": "string"
-                    }
-                }
-            }
-        ],
-        "configuration": {
-            "title": "Kubernetes Debugging Tools",
-            "properties": {
-                "bridgeToKubernetes.disconnectAfterDebugging": {
-                    "type": "boolean",
-                    "default": true,
-                    "description": "Disconnect automatically when debugging stops. If unchecked, the connection to the service in the cluster will be kept alive when debugging stops. You can manually disconnect using the \"Kubernetes\" status bar menu."
-                }
-            }
+        "properties": {
+          "resource": {
+            "type": "string"
+          },
+          "resourceType": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "array"
+          },
+          "isolateAs": {
+            "type": "string"
+          },
+          "targetCluster": {
+            "type": "string"
+          },
+          "targetNamespace": {
+            "type": "string"
+          },
+          "targetContainer": {
+            "type": "string"
+          },
+          "useKubernetesServiceEnvironmentVariables": {
+            "type": "boolean"
+          }
         }
-    },
-    "scripts": {
-        "vscode:prepublish": "del-cli dist/template && webpack --mode production && cd ./src/template && node ../../node_modules/copy/copy.js ./**/* ../../dist/template",
-        "vscode:package": "node ./node_modules/@vscode/vsce/vsce package",
-        "lint": "node node_modules/tslint/bin/tslint **/*.ts -e **/*.d.ts -e node_modules/**/*.ts -p .",
-        "fixlint": "node node_modules/tslint/bin/tslint **/*.ts -e **/*.d.ts -e node_modules/**/*.ts -p . --fix",
-        "compile": "del-cli dist/template && webpack --mode development && node ./node_modules/copy/copy.js ./src/template/**/* dist/template",
-        "preinstall": "npx npm-force-resolutions",
-        "pretest": "npm run test-compile",
-        "test": "c8 --reporter=lcov node ./out/tests/TestsRunHost.js",
-        "test-compile": "npm run compile && del-cli out/models/recognizers/template && tsc -p ./ && cd ./src/template && node ../../node_modules/copy/copy.js ./**/* ../../out/models/recognizers/template"
-    },
-    "extensionDependencies": [
-        "ms-kubernetes-tools.vscode-kubernetes-tools",
-        "mindaro-dev.file-downloader"
+      },
+      {
+        "type": "bridge-to-kubernetes.service",
+        "required": [
+          "service",
+          "ports"
+        ],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "array"
+          },
+          "isolateAs": {
+            "type": "string"
+          },
+          "targetCluster": {
+            "type": "string"
+          },
+          "targetNamespace": {
+            "type": "string"
+          },
+          "targetContainer": {
+            "type": "string"
+          },
+          "useKubernetesServiceEnvironmentVariables": {
+            "type": "boolean"
+          }
+        }
+      },
+      {
+        "type": "local-process-with-kubernetes.service",
+        "required": [
+          "service",
+          "ports"
+        ],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "array"
+          },
+          "isolateAs": {
+            "type": "string"
+          }
+        }
+      },
+      {
+        "type": "dev-spaces.connect.service",
+        "required": [
+          "service",
+          "ports"
+        ],
+        "properties": {
+          "service": {
+            "type": "string"
+          },
+          "ports": {
+            "type": "array"
+          },
+          "isolateAs": {
+            "type": "string"
+          }
+        }
+      }
     ],
-    "devDependencies": {
-        "@types/chai": "^4.3.5",
-        "@types/glob": "^7.1.1",
-        "@types/got": "^9.6.12",
-        "@types/mocha": "^10.0.1",
-        "@types/node": "^18.11.17",
-        "@types/node-fetch": "^2.6.2",
-        "@types/sinon": "^10.0.16",
-        "@types/vscode": "1.95.0",
-        "@vscode/test-electron": "^2.3.9",
-        "@vscode/vsce": "^2.23.0",
-        "c8": "^8.0.1",
-        "chai": "^4.3.7",
-        "copy": "^0.0.1",
-        "del-cli": "^5.0.0",
-        "eslint": "^8.27.0",
-        "glob": "^10.3.10",
-        "mocha": "^10.2.0",
-        "sinon": "^15.2.0",
-        "source-map-support": "^0.5.12",
-        "ts-loader": "^9.4.2",
-        "typescript": "^5.1.3",
-        "webpack": "^5.97.1",
-        "webpack-cli": "^5.0.1"
-    },
-    "optionalDependencies": {
-        "bufferutil": "^4.0.8",
-        "fsevents": "^2.1.3",
-        "utf-8-validate": "^6.0.3"
-    },
-    "dependencies": {
-        "@kubernetes/client-node": "^0.22.3",
-        "@microsoft/vscode-file-downloader-api": "^1.0.1",
-        "@types/tmp": "^0.1.0",
-        "@vscode/extension-telemetry": "^0.9.6", 
-        "chokidar": "^3.5.3",
-        "command-exists": "^1.2.8",
-        "got": "^11.0.0",
-        "guid-typescript": "^1.0.9",
-        "lodash": "^4.17.21",
-        "node-fetch": "^2.6.7",
-        "opener": "^1.5.1",
-        "portfinder": "^1.0.28",
-        "telaug": "0.0.13",
-        "tmp": "^0.2.1",
-        "username": "^5.1.0",
-        "vscode-kubernetes-tools-api": "^1.3.0",
-        "vscode-tas-client": "^0.1.75",
-        "watchpack": "^2.3.1"
-    },
-    "overrides": {
-        "serialize-javascript": "3.1.0",
-        "execa": "5.1.1"
-    },
-    "homepage": "https://aka.ms/bridge-to-k8s-vscode-quickstart",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Azure/vscode-bridge-to-kubernetes"
-    },
-    "extensionMetadata": {
-        "expectedCLIVersion": "1.0.20240109.1"
+    "configuration": {
+      "title": "Kubernetes Debugging Tools",
+      "properties": {
+        "bridgeToKubernetes.disconnectAfterDebugging": {
+          "type": "boolean",
+          "default": true,
+          "description": "Disconnect automatically when debugging stops. If unchecked, the connection to the service in the cluster will be kept alive when debugging stops. You can manually disconnect using the \"Kubernetes\" status bar menu."
+        }
+      }
     }
+  },
+  "scripts": {
+    "vscode:prepublish": "del-cli dist/template && webpack --mode production && cd ./src/template && node ../../node_modules/copy/copy.js ./**/* ../../dist/template",
+    "vscode:package": "node ./node_modules/@vscode/vsce/vsce package",
+    "lint": "node node_modules/tslint/bin/tslint **/*.ts -e **/*.d.ts -e node_modules/**/*.ts -p .",
+    "fixlint": "node node_modules/tslint/bin/tslint **/*.ts -e **/*.d.ts -e node_modules/**/*.ts -p . --fix",
+    "compile": "del-cli dist/template && webpack --mode development && node ./node_modules/copy/copy.js ./src/template/**/* dist/template",
+    "preinstall": "npx npm-force-resolutions",
+    "pretest": "npm run test-compile",
+    "test": "c8 --reporter=lcov node ./out/tests/TestsRunHost.js",
+    "test-compile": "npm run compile && del-cli out/models/recognizers/template && tsc -p ./ && cd ./src/template && node ../../node_modules/copy/copy.js ./**/* ../../out/models/recognizers/template"
+  },
+  "extensionDependencies": [
+    "ms-kubernetes-tools.vscode-kubernetes-tools",
+    "mindaro-dev.file-downloader"
+  ],
+  "devDependencies": {
+    "@types/chai": "^4.3.5",
+    "@types/glob": "^7.1.1",
+    "@types/got": "^9.6.12",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "^18.11.17",
+    "@types/node-fetch": "^2.6.2",
+    "@types/sinon": "^10.0.16",
+    "@types/vscode": "1.95.0",
+    "@vscode/test-electron": "^2.3.9",
+    "@vscode/vsce": "^2.23.0",
+    "c8": "^8.0.1",
+    "chai": "^4.3.7",
+    "copy": "^0.0.1",
+    "del-cli": "^5.0.0",
+    "eslint": "^8.27.0",
+    "glob": "^10.3.10",
+    "mocha": "^10.2.0",
+    "sinon": "^15.2.0",
+    "source-map-support": "^0.5.12",
+    "ts-loader": "^9.4.2",
+    "typescript": "^5.1.3",
+    "webpack": "^5.97.1",
+    "webpack-cli": "^5.0.1"
+  },
+  "optionalDependencies": {
+    "bufferutil": "^4.0.8",
+    "fsevents": "^2.1.3",
+    "utf-8-validate": "^6.0.3"
+  },
+  "dependencies": {
+    "@kubernetes/client-node": "^0.22.3",
+    "@types/tmp": "^0.1.0",
+    "@vscode/extension-telemetry": "^0.9.6",
+    "chokidar": "^3.5.3",
+    "command-exists": "^1.2.8",
+    "got": "^11.0.0",
+    "guid-typescript": "^1.0.9",
+    "lodash": "^4.17.21",
+    "node-fetch": "^2.6.7",
+    "opener": "^1.5.1",
+    "portfinder": "^1.0.28",
+    "telaug": "0.0.13",
+    "tmp": "^0.2.1",
+    "username": "^5.1.0",
+    "vscode-kubernetes-tools-api": "^1.3.0",
+    "vscode-tas-client": "^0.1.75",
+    "watchpack": "^2.3.1"
+  },
+  "overrides": {
+    "serialize-javascript": "3.1.0",
+    "execa": "5.1.1"
+  },
+  "homepage": "https://aka.ms/bridge-to-k8s-vscode-quickstart",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Azure/vscode-bridge-to-kubernetes"
+  },
+  "extensionMetadata": {
+    "expectedCLIVersion": "1.0.20240109.1"
+  }
 }

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -4,26 +4,13 @@
 'use strict';
 
 export class Constants {
-    /* BinariesUtility V1 & V2 Shared Constants */
-    public static readonly BinariesVersionedUrlProd = `https://bridgetokubernetes.blob.core.windows.net/%s/%s/lks.json`;
-    public static readonly BinariesVersionedUrlStaging = `https://mindarostaging.blob.core.windows.net/%s/%s/lks.json`;
-    public static readonly BinariesVersionedUrlDev = `https://mindaromaster.blob.core.windows.net/%s/%s/lks.json`;
-
     /* BinariesUtilityV2 Constants */
-    public static readonly BinariesLatestVersionUrlProd = `https://aka.ms/bridge-lks-v2`;
-    public static readonly BinariesLatestVersionUrlStaging = `https://aka.ms/bridge-lks-staging-v2`;
-    public static readonly BinariesLatestVersionUrlDev = `https://aka.ms/bridge-lks-dev-v2`;
     public static readonly LegacyBridgeDownloadDirectoryName = `binaries`;
     public static readonly BridgeDownloadDirectoryName = `bridge`;
     public static readonly KubectlDownloadDirectoryName = `kubectl`;
     public static readonly DotNetDownloadDirectoryName = `dotnet`;
     public static readonly KubectlMinVersion = `1.27.3`;
     public static readonly DotNetMinVersion = `7.0.7`;
-
-    /* BinariesUtility Constants */
-    public static readonly CliVersionsUrlProd = `https://aka.ms/bridge-lks`;
-    public static readonly CliVersionsUrlStaging = `https://aka.ms/bridge-lks-staging`;
-    public static readonly CliVersionsUrlDev = `https://aka.ms/bridge-lks-dev`;
     public static readonly CliDownloadDirectoryName = `binaries`;
 
     public static readonly ProductName = `Bridge to Kubernetes`;
@@ -58,7 +45,7 @@ export class Constants {
 
     public static readonly LegacyConnectServiceTaskType3 = `${Constants.TaskSource}.service`;
 
-    public static readonly FileDownloaderMinVersion = `1.0.10`;
+    public static readonly FileDownloaderMinVersion = `1.0.13`;
     public static readonly FileDownloaderVersionError = `${Constants.ProductName} cannot run alongside the extension, File Downloader with version older than '${Constants.FileDownloaderMinVersion}'. Please update the File Downloader extension.`;
 
     public static readonly ListOfErrorMessagesForUsingKubernetesServiceEnvironmentVariables = [

--- a/src/binaries/BinariesUtilityV2.ts
+++ b/src/binaries/BinariesUtilityV2.ts
@@ -3,7 +3,6 @@
 // ----------------------------------------------------------------------------
 'use strict';
 
-import { FileDownloader, getApi as getFileDownloaderApi } from '@microsoft/vscode-file-downloader-api';
 import * as path from 'path';
 import * as process from 'process';
 import * as vscode from 'vscode';
@@ -24,6 +23,7 @@ import { TelemetryEvent } from '../logger/TelemetryEvent';
 import { IDownloadInfo } from '../models/IBinariesDownloadInfo';
 import { AccountContextManager } from '../models/context/AccountContextManager';
 import { EventSource, IReadOnlyEventSource } from '../utility/Event';
+import FileDownloader, { FileDownloadSettings } from '../utility/FileDownloader';
 import { fileSystem } from '../utility/FileSystem';
 import { VersionUtility } from '../utility/VersionUtility';
 import { IBinariesUtility } from './IBinariesUtility';
@@ -154,7 +154,7 @@ export class BinariesUtilityV2 implements IBinariesUtility {
         let kubectlClient: IClient;
         let dotNetClient: IClient = await this.checkIfBinaryExistsAsync(dotNetClientProvider);
         const existingDotNetPath: string = dotNetClient == null ? null : dotNetClient.getExecutablePath();
-        [ bridgeClient, kubectlClient ] = await Promise.all([
+        [bridgeClient, kubectlClient] = await Promise.all([
             this.checkIfBinaryExistsAsync(bridgeClientProvider, existingDotNetPath),
             this.checkIfBinaryExistsAsync(kubectlClientProvider)
         ]);
@@ -168,7 +168,7 @@ export class BinariesUtilityV2 implements IBinariesUtility {
 
         // Callback which tracks the overall download progress of the binaries
         let shouldReportDownloadProgress = true;
-        const currentPercentages: number[] = [ 0, 0, 0 ];
+        const currentPercentages: number[] = [0, 0, 0];
         const overAllDownloadProgressCallBack = (binaryIndex: number, downloadPercent: number): void => {
             currentPercentages[binaryIndex] = downloadPercent;
             if (shouldReportDownloadProgress) {
@@ -190,14 +190,14 @@ export class BinariesUtilityV2 implements IBinariesUtility {
             let downloadingBinaryIndex = 0;
             const downloadBinaryPromises: Promise<string>[] = [
                 dotNetClient == null ? this.downloadBinaryAsync(dotNetClientProvider, overAllDownloadProgressCallBack, downloadingBinaryIndex++)
-                                    : new Promise((resolve): void => resolve(dotNetClient.getExecutablePath())),
+                    : new Promise((resolve): void => resolve(dotNetClient.getExecutablePath())),
                 bridgeClient == null ? this.downloadBinaryAsync(bridgeClientProvider, overAllDownloadProgressCallBack, downloadingBinaryIndex++, bridgeCleanupBeforeDownload)
-                                : new Promise((resolve): void => resolve(bridgeClient.getExecutablePath())),
+                    : new Promise((resolve): void => resolve(bridgeClient.getExecutablePath())),
                 kubectlClient == null ? this.downloadBinaryAsync(kubectlClientProvider, overAllDownloadProgressCallBack, downloadingBinaryIndex++)
-                                    : new Promise((resolve): void => resolve(kubectlClient.getExecutablePath()))
+                    : new Promise((resolve): void => resolve(kubectlClient.getExecutablePath()))
             ];
 
-            [ dotNetPath, bridgePath, kubectlPath ] = await Promise.all(downloadBinaryPromises);
+            [dotNetPath, bridgePath, kubectlPath] = await Promise.all(downloadBinaryPromises);
             downloadSucceeded = true;
         }
         catch (error) {
@@ -216,14 +216,14 @@ export class BinariesUtilityV2 implements IBinariesUtility {
         // Perform validation only for the binaries that have been downloaded
         const postDownloadPromises: Promise<IClient>[] = [
             dotNetClient == null ? this.postDownloadValidationAsync(dotNetClientProvider, dotNetPath)
-                                 : new Promise((resolve): void => resolve(dotNetClient)),
+                : new Promise((resolve): void => resolve(dotNetClient)),
             bridgeClient == null ? this.postDownloadValidationAsync(bridgeClientProvider, bridgePath, dotNetPath)
-                              : new Promise((resolve): void => resolve(bridgeClient)),
+                : new Promise((resolve): void => resolve(bridgeClient)),
             kubectlClient == null ? this.postDownloadValidationAsync(kubectlClientProvider, kubectlPath)
-                                  : new Promise((resolve): void => resolve(kubectlClient))
+                : new Promise((resolve): void => resolve(kubectlClient))
         ];
 
-        [ dotNetClient, bridgeClient, kubectlClient ] = await Promise.all(postDownloadPromises);
+        [dotNetClient, bridgeClient, kubectlClient] = await Promise.all(postDownloadPromises);
 
         // Bridge expects kubectl to be present in its folder, so copy only if kubectl or bridge has been downloaded
         await this.moveKubectlToBridgeFolderIfRequiredAsync(bridgeOrKubectlClientToBeDownloaded, bridgePath, kubectlPath, kubectlClientProvider);
@@ -242,7 +242,7 @@ export class BinariesUtilityV2 implements IBinariesUtility {
             }
         }
 
-        return [ bridgeClient as BridgeClient, kubectlClient as KubectlClient ];
+        return [bridgeClient as BridgeClient, kubectlClient as KubectlClient];
     }
 
     private async postDownloadValidationAsync(clientProvider: IClientProvider, executablePath: string, dotNetPath: string = null): Promise<IClient> {
@@ -253,7 +253,7 @@ export class BinariesUtilityV2 implements IBinariesUtility {
             const commandRunner = new CommandRunner(this._commandEnvironmentVariables);
             const chmodPath = process.platform === `darwin` ? `/bin/chmod` : `chmod`;
             const directoryName: string = await this.getBinariesDirectoryPathAsync(clientProvider.getDownloadDirectoryName());
-            const args: string[] = [ `+x` ];
+            const args: string[] = [`+x`];
             args.push(...clientProvider.getExecutablesToUpdatePermissions());
             await commandRunner.runAsync(chmodPath, args, directoryName);
         }
@@ -279,9 +279,9 @@ export class BinariesUtilityV2 implements IBinariesUtility {
      * Also, performs any clean up before download.
      */
     private async downloadBinaryAsync(clientProvider: IClientProvider,
-                                      overAllDownloadProgressCallBack: (binaryIndex: number, downloadPercent: number) => void,
-                                      downloadingBinaryIndex: number,
-                                      cleanUpBeforeDownload?: () => Promise<void>
+        overAllDownloadProgressCallBack: (binaryIndex: number, downloadPercent: number) => void,
+        downloadingBinaryIndex: number,
+        cleanUpBeforeDownload?: () => Promise<void>
     ): Promise<string> {
         if (cleanUpBeforeDownload != null) {
             this._logger.trace(`Performing clean up before download for client '${clientProvider.Type}'`);
@@ -312,6 +312,14 @@ export class BinariesUtilityV2 implements IBinariesUtility {
         this._logger.trace(`Downloading client ${clientProvider.Type}...`);
         const fileDownloader: FileDownloader = await this.validateAndGetFileDownloaderApiAsync();
         let unzipDirectory: vscode.Uri;
+        const settings: FileDownloadSettings = {
+            makeExecutable: true,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            // needed for github download
+            headers: { "Accept": `application/octet-stream`, "Content-Type": `application/octet-stream` },
+            shouldUnzip: true,
+            retries: 8
+        };
         try {
             unzipDirectory = await fileDownloader.downloadFile(
                 vscode.Uri.parse(downloadInfo.downloadUrl),
@@ -319,10 +327,7 @@ export class BinariesUtilityV2 implements IBinariesUtility {
                 this._context,
                 /*cancellationToken*/ undefined,
                 downloadProgressCallback,
-                {
-                    shouldUnzip: true,
-                    retries: 8
-                }
+                settings
             );
 
             const binaryPath = path.join(unzipDirectory.fsPath, clientProvider.getExecutableFilePath());
@@ -402,9 +407,9 @@ export class BinariesUtilityV2 implements IBinariesUtility {
     }
 
     private async moveKubectlToBridgeFolderIfRequiredAsync(bridgeOrKubectlClientDownloaded: boolean,
-                                                           bridgePath: string,
-                                                           kubectlPath: string,
-                                                           kubectlClientProvider: IClientProvider
+        bridgePath: string,
+        kubectlPath: string,
+        kubectlClientProvider: IClientProvider
     ): Promise<void> {
         try {
             const kubectlExecutableFilePathForBridge: string = path.join(path.dirname(bridgePath), kubectlClientProvider.getDownloadDirectoryName(), kubectlClientProvider.getExecutableFilePath());
@@ -500,7 +505,7 @@ export class BinariesUtilityV2 implements IBinariesUtility {
                 throw error;
             }
 
-            this._fileDownloader = await getFileDownloaderApi();
+            this._fileDownloader = await this.getApi();
         }
 
         return this._fileDownloader;
@@ -514,5 +519,16 @@ export class BinariesUtilityV2 implements IBinariesUtility {
             throw error;
         }
         return fileDownloaderExtension;
+    }
+
+    public async getApi(): Promise<FileDownloader> {
+        let _extension: vscode.Extension<FileDownloader> | undefined;
+        if (_extension == null) {
+            _extension = this.getFileDownloaderExtension();
+        }
+        if (!_extension.isActive) {
+            await _extension.activate();
+        }
+        return _extension.exports;
     }
 }

--- a/src/binaries/BinariesUtilityV2.ts
+++ b/src/binaries/BinariesUtilityV2.ts
@@ -522,13 +522,12 @@ export class BinariesUtilityV2 implements IBinariesUtility {
     }
 
     public async getApi(): Promise<FileDownloader> {
-        let _extension: vscode.Extension<FileDownloader> | undefined;
-        if (_extension == null) {
-            _extension = this.getFileDownloaderExtension();
-        }
+        let _extension = this.getFileDownloaderExtension();
+
         if (!_extension.isActive) {
             await _extension.activate();
         }
+
         return _extension.exports;
     }
 }

--- a/src/clients/BinariesVersionClient.ts
+++ b/src/clients/BinariesVersionClient.ts
@@ -100,7 +100,7 @@ export class BinariesVersionClient {
         let jsonContent: any;
         let filePath: PathOrFileDescriptor;
         try {
-            filePath = path.join(__dirname, '/src/utility/BinaryDownloadInfo.json');
+            filePath = path.join(__dirname, '..', 'utility', 'BinaryDownloadInfo.json');
             const rawContent: string = await fileSystem.readFileAsync(filePath, `utf8`);
             jsonContent = JSON.parse(rawContent);
             if (jsonContent == null) {
@@ -112,5 +112,6 @@ export class BinariesVersionClient {
             this._logger.error(TelemetryEvent.UnexpectedError, userFriendlyError);
             throw userFriendlyError;
         }
+        return jsonContent;
     }
 }

--- a/src/clients/BinariesVersionClient.ts
+++ b/src/clients/BinariesVersionClient.ts
@@ -44,7 +44,7 @@ export class BinariesVersionClient {
             const getDownloadInfoAsyncFn = async (): Promise<IBinariesDownloadInfo> => {
 
                 // Get latest download URL and checksum
-                const binaryVersionsJson: any = this.getBinariesJsonContent();
+                const binaryVersionsJson: any = await this.getBinariesJsonContent();
                 const osString: string = this.getOsString();
                 const version: string = binaryVersionsJson[`version`];
                 const binariesDownloadInfo: object = binaryVersionsJson[osString];
@@ -100,7 +100,7 @@ export class BinariesVersionClient {
         let jsonContent: any;
         let filePath: PathOrFileDescriptor;
         try {
-            filePath = path.join(__dirname, '..', 'utility', 'BinaryDownloadInfo.json');
+            filePath = path.join(__dirname, '..', 'src', 'utility', 'BinaryDownloadInfo.json');
             const rawContent: string = await fileSystem.readFileAsync(filePath, `utf8`);
             jsonContent = JSON.parse(rawContent);
             if (jsonContent == null) {

--- a/src/utility/BinaryDownloadInfo.json
+++ b/src/utility/BinaryDownloadInfo.json
@@ -17,7 +17,7 @@
   "linux_arm64": {
     "bridge": {
       "sha256hash": "39E86AD8D3C60FE9B5F462F6947B632E0BF57AE8C1B61CF2DFABFB8A9A324756",
-      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-linux-arm64.zip"
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/lpk-linux-arm64.zip"
     },
     "kubectl": {
       "sha256hash": "01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900",
@@ -31,7 +31,7 @@
   "osx": {
     "bridge": {
       "sha256hash": "F60F28FACE7887B58768112F65D092146692679691E72C19C1A822C28876503C",
-      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-osx.zip"
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/lpk-osx.zip"
     },
     "kubectl": {
       "sha256hash": "D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9",
@@ -45,7 +45,7 @@
   "win": {
     "bridge": {
       "sha256hash": "29CE6477ABAF4003947EC1D83B62DB32C5A03D24F4444E4CCB24BF41F5A0C232",
-      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-win.zip"
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/lpk-win.zip"
     },
     "kubectl": {
       "sha256hash": "5490F9B60E4C2C4229CA00FBFA946AE65655F0739BE9714C6A0A0FB7BE2A6F2C",
@@ -59,7 +59,7 @@
   "osx_arm64": {
     "bridge": {
       "sha256hash": "32696DA350D8B5381234DFF5667F150DEE47A3EC9DF91CB00FCBEBEEE76CB026",
-      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-osx-arm64.zip"
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/lpk-osx-arm64.zip"
     },
     "kubectl": {
       "sha256hash": "D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9",
@@ -73,7 +73,7 @@
   "linux": {
     "bridge": {
       "sha256hash": "ACA7355ADBE0FA4277C4A74C8A67B5916555035F7E66F5DDD0D4E26259D95FA4",
-      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-linux.zip"
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/lpk-linux.zip"
     },
     "kubectl": {
       "sha256hash": "01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900",

--- a/src/utility/BinaryDownloadInfo.json
+++ b/src/utility/BinaryDownloadInfo.json
@@ -1,0 +1,87 @@
+{
+  "version": "1.0.20240109.1",
+  "win_arm64": {
+    "bridge": {
+      "sha256hash": "7794A8396CEB719C13A416F862F15D31DDA9215BC10720F379D8353C70D36095",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/lpk-win-arm64.zip"
+    },
+    "kubectl": {
+      "sha256hash": "5490F9B60E4C2C4229CA00FBFA946AE65655F0739BE9714C6A0A0FB7BE2A6F2C",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/kubectl-win-arm64.zip"
+    },
+    "dotnetruntime": {
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-win-arm64.zip",
+      "sha512hash": "902488cbfee81dd5e1009eb86ab82d479ed7d9c44e4e4b6bb3df90a68eea65c0140978b02f46f9f6d0847466e1de73e9551688a79082e0679350a46276f441f9"
+    }
+  },
+  "linux_arm64": {
+    "bridge": {
+      "sha256hash": "39E86AD8D3C60FE9B5F462F6947B632E0BF57AE8C1B61CF2DFABFB8A9A324756",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-linux-arm64.zip"
+    },
+    "kubectl": {
+      "sha256hash": "01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/kubectl-linux-arm64.zip"
+    },
+    "dotnetruntime": {
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux-arm64.zip",
+      "sha512hash": "814db12231db89d9935404ec6693b3fb50ad022c0affbc131d657878e194274f1af5e92dd32c2c4f2a78a7e38d0c18a46ba4ecc67630ca3adf5b7550367c2366"
+    }
+  },
+  "osx": {
+    "bridge": {
+      "sha256hash": "F60F28FACE7887B58768112F65D092146692679691E72C19C1A822C28876503C",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-osx.zip"
+    },
+    "kubectl": {
+      "sha256hash": "D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/kubectl-osx.zip"
+    },
+    "dotnetruntime": {
+      "sha256hash": "D25F8BB708C364678AAA0F3798F5EADD1BE46800376F15D2F12C785C74AF8443",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-osx.zip"
+    }
+  },
+  "win": {
+    "bridge": {
+      "sha256hash": "29CE6477ABAF4003947EC1D83B62DB32C5A03D24F4444E4CCB24BF41F5A0C232",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-win.zip"
+    },
+    "kubectl": {
+      "sha256hash": "5490F9B60E4C2C4229CA00FBFA946AE65655F0739BE9714C6A0A0FB7BE2A6F2C",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/kubectl-win.zip"
+    },
+    "dotnetruntime": {
+      "sha256hash": "0FCA9F2AB829C85615007EA646CF436D2E90C9A4095C84C2F9EB3EC0754468A8",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-win.zip"
+    }
+  },
+  "osx_arm64": {
+    "bridge": {
+      "sha256hash": "32696DA350D8B5381234DFF5667F150DEE47A3EC9DF91CB00FCBEBEEE76CB026",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-osx-arm64.zip"
+    },
+    "kubectl": {
+      "sha256hash": "D24EAFEC39EB2393DBA0088B762953BEDCC04156AC9E324FA290476BD3C888B9",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/kubectl-osx-arm64.zip"
+    },
+    "dotnetruntime": {
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-osx-arm64.zip",
+      "sha512hash": "e6979ab34bea777f1f48bf9208a024b33b1685ec236f13c609975ebc7e1f641806b47daefb9ff1f74f675ee6242b628edd615982bc9c014d18e18cd2662171a8"
+    }
+  },
+  "linux": {
+    "bridge": {
+      "sha256hash": "ACA7355ADBE0FA4277C4A74C8A67B5916555035F7E66F5DDD0D4E26259D95FA4",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip/lpk-linux.zip"
+    },
+    "kubectl": {
+      "sha256hash": "01B76D4E4A9081452932F27C767C9D8F3507C8AD3CC9269CEB16729F4D0ED900",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/kubectl-linux.zip"
+    },
+    "dotnetruntime": {
+      "sha256hash": "801D9D251D07B9A88195450FCBFD70C7507CEEEF05D5F0E88CC14CEBFCC10F4B",
+      "url": "https://github.com/Azure/Bridge-To-Kubernetes/releases/download/1.0.20240109.1/dotnetruntime-linux.zip"
+    }
+  }
+}

--- a/src/utility/FileDownloader.ts
+++ b/src/utility/FileDownloader.ts
@@ -1,0 +1,107 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { CancellationToken, ExtensionContext, Uri } from "vscode";
+
+export interface FileDownloadSettings {
+    /**
+     * Timeout in milliseconds for the request.
+     * @default 5000
+     */
+    timeoutInMs?: number;
+    /**
+     * Number of retries for the request.
+     * @default 5
+     */
+    retries?: number;
+    /**
+     * Delay in milliseconds between retries.
+     * @default 100
+     */
+    retryDelayInMs?: number;
+    /**
+     * Whether to unzip the downloaded file.
+     * @default false
+     */
+    shouldUnzip?: boolean;
+    /**
+     * Whether to make the downloaded file executable.
+     * @default false
+     */
+    makeExecutable?: boolean;
+    /**
+     * Additional headers to send with the request.
+     * @default undefined
+     * @example
+     * {
+     *   headers: {"Accept": `application/octet-stream`, "Content-Type": `application/octet-stream`}
+     * }
+     */
+    headers?: Record<string, string | number | boolean> | undefined;
+}
+
+export default interface FileDownloader {
+    /**
+     * Downloads a file from a URL and gives back the file path, file name, and a checksum. Allows you to specify the
+     * timeout, the number of acceptable retries, whether or not to unzip the file, and whether or not to check the
+     * downloaded file against a checksum.
+     *
+     * @param url the URL to make a GET request to
+     * @param filename the name of the file to retrieve the stored data in
+     * @param context the ExtensionContext of the extension downloading the file
+     * @param cancellationToken token that allows cancelling the download
+     * @param onDownloadProgressChange a callback that gets called every time a new chunk of data comes from the server.
+     * Note: the totalBytes parameter corresponds to the content-length provided by the server in the GET response
+     * header. It could differ from the actual number of bytes in the download, or may not be provided at all.
+     * @param settings optional additional settings for the download
+     * @returns the URI containing the path to the downloaded file or unzipped directory
+     */
+    downloadFile(
+        url: Uri,
+        filename: string,
+        context: ExtensionContext,
+        cancellationToken?: CancellationToken,
+        onDownloadProgressChange?: (downloadedBytes: number, totalBytes: number | undefined) => void,
+        settings?: FileDownloadSettings
+    ): Promise<Uri>;
+    /**
+     * Returns the paths of all files that exist in the consumer extensions' download folder
+     *
+     * @param context the context for the extension downloading the file
+     * @returns an array of downloaded file or folder paths
+     */
+    listDownloadedItems(context: ExtensionContext): Promise<Uri[]>;
+    /**
+     * Gets the path to a downloaded or unzipped item.
+     *
+     * @param filename the name of the file or folder to remove
+     * @param context The calling extension's context
+     * @returns the path to the downloaded file (or folder if the download was unzipped)
+     * @throws FileNotFoundError if there is no such file or folder
+     */
+    getItem(filename: string, context: ExtensionContext): Promise<Uri>;
+    /**
+     * Gets the path to a downloaded or unzipped item, but returns undefined instead of throwing an error if the file
+     * isn't found.
+     *
+     * @param filename the name of the file or folder to remove
+     * @param context The calling extension's context
+     * @returns the path to the downloaded file (or folder if the download was unzipped)
+     */
+    tryGetItem(filename: string, context: ExtensionContext): Promise<Uri | undefined>;
+    /**
+     * Deletes the file specified by `filename`. The filename should match the name that the file was downloaded with.
+     * Does not throw an error if the file doesn't exist, as the filesystem is already in the desired state.
+     *
+     * @param filename the name of the file or folder to remove
+     * @context the context of the extension that downloaded the file
+     */
+    deleteItem(filename: string, context: ExtensionContext): Promise<void>;
+    /**
+     * Clears all files downloaded by the extension specified in the context. Does nothing if no files have been
+     * downloaded.
+     *
+     * @param context the context of the extension that downloaded the file(s)
+     */
+    deleteAllItems(context: ExtensionContext): Promise<void>;
+}


### PR DESCRIPTION
This PR updates this extension to download from GitHub release instead from the storage blob. Please read https://github.com/Azure/Bridge-To-Kubernetes/issues/645, this is last update for this extension, soon will be deprecated. Thank you all. 